### PR TITLE
[BE] 데일리 투두 & 투두 수행 API 문서 작성 및 Mock API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -1,5 +1,5 @@
 [[challenge-group-api]]
-== Challenge Group API
+== 챌린지 그룹 API
 
 [[create-challenge-group]]
 === 챌린지 그룹 생성

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -1,5 +1,5 @@
 [[daily-todo-api]]
-== Daily Todo API
+== 데일리 투두 API
 
 [[create-daily-todos]]
 === 데일리 투두 작성

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -1,0 +1,45 @@
+[[daily-todo-api]]
+== Daily Todo API
+
+[[create-daily-todos]]
+=== 데일리 투두 작성
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/http-response.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/response-fields.adoc[]
+
+[[get-yesterday-daily-todos]]
+=== 어제 작성한 투두 내용 조회
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/http-response.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/response-fields.adoc[]

--- a/src/docs/asciidoc/dailytodoproof/daily-todo-proof.adoc
+++ b/src/docs/asciidoc/dailytodoproof/daily-todo-proof.adoc
@@ -1,0 +1,68 @@
+[[daily-todo-proof-api]]
+== 데일리 투두 수행 인증 API
+
+[[review-daily-todo-proof]]
+=== 데일리 투두 수행 인증 검사
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-proof-controller-docs-test/review-daily-todo-proof/http-request.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/review-daily-todo-proof/path-parameters.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/review-daily-todo-proof/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-proof-controller-docs-test/review-daily-todo-proof/http-response.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/review-daily-todo-proof/response-fields.adoc[]
+
+[[get-daily-todo-proofs-for-review]]
+=== 검사할 투두 수행 인증 전체 조회
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proofs-for-review/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proofs-for-review/http-response.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proofs-for-review/response-fields.adoc[]
+
+[[get-daily-todo-proof-for-review-by-id]]
+=== 검사할 특정 투두 수행 인증 상세 조회
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proof-for-review-by-id/http-request.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proof-for-review-by-id/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proof-for-review-by-id/http-response.adoc[]
+include::{snippets}/daily-todo-proof-controller-docs-test/get-daily-todo-proof-for-review-by-id/response-fields.adoc[]

--- a/src/docs/asciidoc/enum/daily-todo-proof-review-result.adoc
+++ b/src/docs/asciidoc/enum/daily-todo-proof-review-result.adoc
@@ -1,0 +1,5 @@
+:doctype: book
+:icons: font
+
+[[product-category]]
+include::{snippets}/common-docs-controller-test/enums/custom-response-fields-beneath-dailyTodoProofReviewResult.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,5 @@ endif::[]
 
 include::common/overview.adoc[]
 include::challengegroup/challenge-group.adoc[]
+include::dailytodo/daily-todo.adoc[]
+include::dailytodoproof/daily-todo-proof.adoc[]

--- a/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupDurationOption.java
+++ b/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupDurationOption.java
@@ -1,27 +1,15 @@
 package site.dogether.challengegroup.domain;
 
 import lombok.RequiredArgsConstructor;
-import site.dogether.common.docs.RestDocsEnumType;
 
 @RequiredArgsConstructor
-public enum ChallengeGroupDurationOption implements RestDocsEnumType {
+public enum ChallengeGroupDurationOption {
 
-    THREE_DAYS(3, "3일"),
-    SEVEN_DAYS(7, "7일"),
-    FOURTEEN_DAYS(14, "14일"),
-    TWENTY_EIGHT_DAYS(28, "28일")
+    THREE_DAYS(3),
+    SEVEN_DAYS(7),
+    FOURTEEN_DAYS(14),
+    TWENTY_EIGHT_DAYS(28)
     ;
 
-    private final int days;
-    private final String description;
-
-    @Override
-    public String getDescription() {
-        return this.description;
-    }
-
-    @Override
-    public String getValue() {
-        return String.valueOf(this.days);
-    }
+    private final int value;
 }

--- a/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupDurationOption.java
+++ b/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupDurationOption.java
@@ -1,10 +1,10 @@
 package site.dogether.challengegroup.domain;
 
 import lombok.RequiredArgsConstructor;
-import site.dogether.common.constant.EnumType;
+import site.dogether.common.docs.RestDocsEnumType;
 
 @RequiredArgsConstructor
-public enum ChallengeGroupDurationOption implements EnumType {
+public enum ChallengeGroupDurationOption implements RestDocsEnumType {
 
     THREE_DAYS(3, "3일"),
     SEVEN_DAYS(7, "7일"),

--- a/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupStartAtOption.java
+++ b/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupStartAtOption.java
@@ -1,24 +1,8 @@
 package site.dogether.challengegroup.domain;
 
-import lombok.RequiredArgsConstructor;
-import site.dogether.common.docs.RestDocsEnumType;
+public enum ChallengeGroupStartAtOption {
 
-@RequiredArgsConstructor
-public enum ChallengeGroupStartAtOption implements RestDocsEnumType {
-
-    TODAY("오늘부터"),
-    TOMORROW("내일부터")
+    TODAY,
+    TOMORROW
     ;
-
-    private final String description;
-
-    @Override
-    public String getDescription() {
-        return this.description;
-    }
-
-    @Override
-    public String getValue() {
-        return this.name();
-    }
 }

--- a/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupStartAtOption.java
+++ b/src/main/java/site/dogether/challengegroup/domain/ChallengeGroupStartAtOption.java
@@ -1,10 +1,10 @@
 package site.dogether.challengegroup.domain;
 
 import lombok.RequiredArgsConstructor;
-import site.dogether.common.constant.EnumType;
+import site.dogether.common.docs.RestDocsEnumType;
 
 @RequiredArgsConstructor
-public enum ChallengeGroupStartAtOption implements EnumType {
+public enum ChallengeGroupStartAtOption implements RestDocsEnumType {
 
     TODAY("오늘부터"),
     TOMORROW("내일부터")

--- a/src/main/java/site/dogether/common/constant/EnumType.java
+++ b/src/main/java/site/dogether/common/constant/EnumType.java
@@ -1,7 +1,0 @@
-package site.dogether.common.constant;
-
-public interface EnumType {
-
-    String getDescription();
-    String getValue();
-}

--- a/src/main/java/site/dogether/common/docs/RestDocsEnumType.java
+++ b/src/main/java/site/dogether/common/docs/RestDocsEnumType.java
@@ -1,0 +1,7 @@
+package site.dogether.common.docs;
+
+public interface RestDocsEnumType {
+
+    String getDescription();
+    String getValue();
+}

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -1,0 +1,40 @@
+package site.dogether.dailytodo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.dogether.common.controller.response.ApiResponse;
+import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
+import site.dogether.dailytodo.controller.request.GetYesterdayDailyTodosResponse;
+
+import java.util.List;
+
+import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.CREATE_DAILY_TODOS;
+import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.GET_YESTERDAY_DAILY_TODOS;
+
+@RequestMapping("/api/todos")
+@RestController()
+public class DailyTodoController {
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createDailyTodos(
+        @RequestBody final CreateDailyTodosRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(CREATE_DAILY_TODOS));
+    }
+
+    /**
+     * 클라이언트 미디어 전달 방식이 결정되면 작성
+     */
+//    @PostMapping("/{todoId}/certificate")
+//    public ResponseEntity<ApiResponse<>>
+
+    @GetMapping("/my/yesterday")
+    public ResponseEntity<ApiResponse<GetYesterdayDailyTodosResponse>> getYesterdayDailyTodos() {
+        return ResponseEntity.ok(ApiResponse.successWithData(
+            GET_YESTERDAY_DAILY_TODOS,
+            new GetYesterdayDailyTodosResponse(
+                List.of(
+                    "푸쉬업 10회",
+                    "프로그래머스 코테 두 문제 풀기",
+                    "스프링 강의 3개 듣기"))));
+    }
+}

--- a/src/main/java/site/dogether/dailytodo/controller/request/CreateDailyTodosRequest.java
+++ b/src/main/java/site/dogether/dailytodo/controller/request/CreateDailyTodosRequest.java
@@ -1,0 +1,6 @@
+package site.dogether.dailytodo.controller.request;
+
+import java.util.List;
+
+public record CreateDailyTodosRequest(List<String> todos) {
+}

--- a/src/main/java/site/dogether/dailytodo/controller/request/GetYesterdayDailyTodosResponse.java
+++ b/src/main/java/site/dogether/dailytodo/controller/request/GetYesterdayDailyTodosResponse.java
@@ -1,0 +1,6 @@
+package site.dogether.dailytodo.controller.request;
+
+import java.util.List;
+
+public record GetYesterdayDailyTodosResponse(List<String> todos) {
+}

--- a/src/main/java/site/dogether/dailytodo/controller/request/ProveDailyTodoRequest.java
+++ b/src/main/java/site/dogether/dailytodo/controller/request/ProveDailyTodoRequest.java
@@ -1,0 +1,4 @@
+package site.dogether.dailytodo.controller.request;
+
+public record ProveDailyTodoRequest(String content) {
+}

--- a/src/main/java/site/dogether/dailytodo/controller/response/DailyTodoSuccessCode.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/DailyTodoSuccessCode.java
@@ -1,0 +1,18 @@
+package site.dogether.dailytodo.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.common.controller.response.SuccessCode;
+
+@RequiredArgsConstructor
+@Getter
+public enum DailyTodoSuccessCode implements SuccessCode {
+
+    CREATE_DAILY_TODOS("DTS-0001", "데일리 투두가 작성되었습니다."),
+    CERTIFICATE_DAILY_TODO("DTS-0002", "데일리 투두 수행 인증이 완료되었습니다."),
+    GET_YESTERDAY_DAILY_TODOS("DTS-0003", "어제 작성된 데일리 투두 내용들이 조회되었습니다."),
+    ;
+
+    private final String value;
+    private final String message;
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/DailyTodoProofController.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/DailyTodoProofController.java
@@ -1,0 +1,61 @@
+package site.dogether.dailytodoproof.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.dogether.common.controller.response.ApiResponse;
+import site.dogether.dailytodoproof.controller.request.ReviewDailyTodoProofRequest;
+import site.dogether.dailytodoproof.controller.response.GetDailyTodoProofForReviewByIdResponse;
+import site.dogether.dailytodoproof.controller.response.GetDailyTodoProofsForReviewResponse;
+import site.dogether.dailytodoproof.controller.response.DailyTodoProofResponse;
+
+import java.util.List;
+
+import static site.dogether.dailytodoproof.controller.response.DailyTodoProofSuccessCode.*;
+
+@RequestMapping("/api/todo-proofs")
+@RestController
+public class DailyTodoProofController {
+
+    @PostMapping("{todoProofId}/review")
+    public ResponseEntity<ApiResponse<Void>> reviewDailyTodoProof(
+        @PathVariable Long todoProofId,
+        @RequestBody final ReviewDailyTodoProofRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(REVIEW_DAILY_TODO_PROOF));
+    }
+
+    @GetMapping("/pending-review")
+    public ResponseEntity<ApiResponse<GetDailyTodoProofsForReviewResponse>> getDailyTodoProofsForReview() {
+        return ResponseEntity.ok(ApiResponse.successWithData(
+            GET_DAILY_TODO_PROOFS_FOR_REVIEW,
+            new GetDailyTodoProofsForReviewResponse(
+                List.of(
+                    new DailyTodoProofResponse(
+                        1L,
+                        "나 진짜진짜 열심히 했어... ㄹㅇ...",
+                        List.of(
+                            "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
+                            "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e2.png"),
+                        "유산소 & 무산소 1시간 조지기"),
+                    new DailyTodoProofResponse(
+                        2L,
+                        "공부까지 갓벽...",
+                        List.of(
+                            "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/s1.png",
+                            "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/s2.png"),
+                        "공부 3시간 조지기")))));
+    }
+
+    @GetMapping("/pending-review/{todoProofId}")
+    public ResponseEntity<ApiResponse<GetDailyTodoProofForReviewByIdResponse>> getDailyTodoProofForReviewById(@PathVariable Long todoProofId) {
+        return ResponseEntity.ok(ApiResponse.successWithData(
+            GET_DAILY_TODO_PROOF_FOR_REVIEW_BY_ID,
+            new GetDailyTodoProofForReviewByIdResponse(
+                new DailyTodoProofResponse(
+                    1L,
+                    "나 진짜진짜 열심히 했어... ㄹㅇ...",
+                    List.of(
+                        "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
+                        "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e2.png"),
+                    "유산소 & 무산소 1시간 조지기"))));
+    }
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/request/ReviewDailyTodoProofRequest.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/request/ReviewDailyTodoProofRequest.java
@@ -1,0 +1,4 @@
+package site.dogether.dailytodoproof.controller.request;
+
+public record ReviewDailyTodoProofRequest(String result, String rejectReason) {
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/response/DailyTodoProofResponse.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/response/DailyTodoProofResponse.java
@@ -1,0 +1,11 @@
+package site.dogether.dailytodoproof.controller.response;
+
+import java.util.List;
+
+public record DailyTodoProofResponse(
+    Long id,
+    String content,
+    List<String> proofMediaUrls,
+    String todoContent
+) {
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/response/DailyTodoProofSuccessCode.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/response/DailyTodoProofSuccessCode.java
@@ -1,0 +1,18 @@
+package site.dogether.dailytodoproof.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.common.controller.response.SuccessCode;
+
+@RequiredArgsConstructor
+@Getter
+public enum DailyTodoProofSuccessCode implements SuccessCode {
+
+    REVIEW_DAILY_TODO_PROOF("TPS-0001", "데일리 투두 수행 인증 검사가 완료되었습니다."),
+    GET_DAILY_TODO_PROOFS_FOR_REVIEW("TPS-0002", "검사할 투두 인증글을 모두 조회하였습니다."),
+    GET_DAILY_TODO_PROOF_FOR_REVIEW_BY_ID("TPS-0003", "검사할 투두 인증글을 조회하였습니다."),
+    ;
+
+    private final String value;
+    private final String message;
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/response/GetDailyTodoProofForReviewByIdResponse.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/response/GetDailyTodoProofForReviewByIdResponse.java
@@ -1,0 +1,6 @@
+package site.dogether.dailytodoproof.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public record GetDailyTodoProofForReviewByIdResponse(@JsonUnwrapped DailyTodoProofResponse todoProof) {
+}

--- a/src/main/java/site/dogether/dailytodoproof/controller/response/GetDailyTodoProofsForReviewResponse.java
+++ b/src/main/java/site/dogether/dailytodoproof/controller/response/GetDailyTodoProofsForReviewResponse.java
@@ -1,0 +1,6 @@
+package site.dogether.dailytodoproof.controller.response;
+
+import java.util.List;
+
+public record GetDailyTodoProofsForReviewResponse(List<DailyTodoProofResponse> todoProofs) {
+}

--- a/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
+++ b/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
@@ -1,23 +1,8 @@
 package site.dogether.dailytodoproof.domain;
 
-import lombok.RequiredArgsConstructor;
-import site.dogether.common.docs.RestDocsEnumType;
+public enum DailyTodoProofReviewResult {
 
-@RequiredArgsConstructor
-public enum DailyTodoProofReviewResult implements RestDocsEnumType {
-    APPROVE("인정"),
-    REJECT("노인정")
+    APPROVE,
+    REJECT
     ;
-
-    private final String description;
-
-    @Override
-    public String getDescription() {
-        return this.description;
-    }
-
-    @Override
-    public String getValue() {
-        return this.name();
-    }
 }

--- a/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
+++ b/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
@@ -1,0 +1,23 @@
+package site.dogether.dailytodoproof.domain;
+
+import lombok.RequiredArgsConstructor;
+import site.dogether.common.constant.EnumType;
+
+@RequiredArgsConstructor
+public enum DailyTodoProofReviewResult implements EnumType {
+    APPROVE("인정"),
+    REJECT("노인정")
+    ;
+
+    private final String description;
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public String getValue() {
+        return this.name();
+    }
+}

--- a/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
+++ b/src/main/java/site/dogether/dailytodoproof/domain/DailyTodoProofReviewResult.java
@@ -1,10 +1,10 @@
 package site.dogether.dailytodoproof.domain;
 
 import lombok.RequiredArgsConstructor;
-import site.dogether.common.constant.EnumType;
+import site.dogether.common.docs.RestDocsEnumType;
 
 @RequiredArgsConstructor
-public enum DailyTodoProofReviewResult implements EnumType {
+public enum DailyTodoProofReviewResult implements RestDocsEnumType {
     APPROVE("인정"),
     REJECT("노인정")
     ;

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -184,7 +184,8 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.ranking")
                         .description("그룹 내 활동 순위")
-                        .type(JsonFieldType.ARRAY),
+                        .type(JsonFieldType.ARRAY)
+                        .optional(),
                     fieldWithPath("data.ranking[].rank")
                         .description("순위")
                         .type(JsonFieldType.NUMBER),

--- a/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupDurationOptionDocs.java
+++ b/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupDurationOptionDocs.java
@@ -1,0 +1,19 @@
+package site.dogether.docs.challengegroup.enumtype;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.docs.util.RestDocsEnumType;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeGroupDurationOptionDocs implements RestDocsEnumType {
+
+    THREE_DAYS("3일", "3"),
+    SEVEN_DAYS("7일", "7"),
+    FOURTEEN_DAYS("14일", "14"),
+    TWENTY_EIGHT_DAYS("28일", "28")
+    ;
+
+    private final String description;
+    private final String requestValue;
+}

--- a/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupDurationOptionDocs.java
+++ b/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupDurationOptionDocs.java
@@ -2,6 +2,7 @@ package site.dogether.docs.challengegroup.enumtype;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import site.dogether.challengegroup.domain.ChallengeGroupDurationOption;
 import site.dogether.docs.util.RestDocsEnumType;
 
 @Getter
@@ -14,6 +15,14 @@ public enum ChallengeGroupDurationOptionDocs implements RestDocsEnumType {
     TWENTY_EIGHT_DAYS("28일", "28")
     ;
 
+    private static final int enumValueCount = ChallengeGroupDurationOption.values().length;
+
     private final String description;
     private final String requestValue;
+
+    public static RestDocsEnumType[] getValues() {
+        final ChallengeGroupDurationOptionDocs[] values = ChallengeGroupDurationOptionDocs.values();
+        RestDocsEnumType.checkDocsValueCountIsEqualToEnumValueCount(enumValueCount, values.length);
+        return values;
+    }
 }

--- a/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStartAtOptionDocs.java
+++ b/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStartAtOptionDocs.java
@@ -2,6 +2,7 @@ package site.dogether.docs.challengegroup.enumtype;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import site.dogether.challengegroup.domain.ChallengeGroupStartAtOption;
 import site.dogether.docs.util.RestDocsEnumType;
 
 @Getter
@@ -12,6 +13,14 @@ public enum ChallengeGroupStartAtOptionDocs implements RestDocsEnumType {
     TOMORROW("내일부터", "TOMORROW")
     ;
 
+    private static final int enumValueCount = ChallengeGroupStartAtOption.values().length;
+
     private final String description;
     private final String requestValue;
+
+    public static RestDocsEnumType[] getValues() {
+        final ChallengeGroupStartAtOptionDocs[] values = ChallengeGroupStartAtOptionDocs.values();
+        RestDocsEnumType.checkDocsValueCountIsEqualToEnumValueCount(enumValueCount, values.length);
+        return values;
+    }
 }

--- a/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStartAtOptionDocs.java
+++ b/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStartAtOptionDocs.java
@@ -1,0 +1,17 @@
+package site.dogether.docs.challengegroup.enumtype;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.docs.util.RestDocsEnumType;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeGroupStartAtOptionDocs implements RestDocsEnumType {
+
+    TODAY("오늘부터", "TODAY"),
+    TOMORROW("내일부터", "TOMORROW")
+    ;
+
+    private final String description;
+    private final String requestValue;
+}

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -1,0 +1,81 @@
+package site.dogether.docs.dailytodo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import site.dogether.dailytodo.controller.DailyTodoController;
+import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
+import site.dogether.docs.util.RestDocsSupport;
+
+import java.util.List;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("데일리 투두 API 문서화 테스트")
+public class DailyTodoControllerDocsTest extends RestDocsSupport {
+
+    @Override
+    protected Object initController() {
+        return new DailyTodoController();
+    }
+
+    @DisplayName("데일리 투두 작성 API")
+    @Test        
+    void createDailyTodos() throws Exception {
+        final CreateDailyTodosRequest request = new CreateDailyTodosRequest(List.of(
+            "프로그래머스 코테 두 문제 풀기",
+            "저녁 운동 조지기",
+            "감정 회고록 작성하기"
+        ));
+
+        mockMvc.perform(
+                post("/api/todos")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(convertToJson(request)))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                requestFields(
+                    fieldWithPath("todos")
+                        .description("데일리 투두 리스트")
+                        .type(JsonFieldType.ARRAY)
+                        .attributes(constraints(
+                            "그룹장 외 참여한 사람이 없다면 투두 작성 불가, " +
+                                "투두 개수는 2 ~ 그룹에서 정한 하루 최대 제한 개수 이하, " +
+                                "투두 항목은 2 ~ 20 길이 문자열"))),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING))));
+    }
+    
+    @DisplayName("어제 작성한 투두 내용 조회 API")
+    @Test        
+    void getYesterdayDailyTodos() throws Exception {
+        mockMvc.perform(
+                get("/api/todos/my/yesterday")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todos")
+                        .description("어제 작성한 투두 내용 리스트")
+                        .optional()
+                        .type(JsonFieldType.ARRAY)
+                )));
+    }
+}

--- a/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
@@ -1,0 +1,140 @@
+package site.dogether.docs.dailytodoproof;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import site.dogether.dailytodoproof.controller.DailyTodoProofController;
+import site.dogether.dailytodoproof.controller.request.ReviewDailyTodoProofRequest;
+import site.dogether.docs.util.RestDocsSupport;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static site.dogether.docs.util.DocumentLinkGenerator.*;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.*;
+
+@DisplayName("데일리 투두 수행 인증 API 문서화 테스트")
+public class DailyTodoProofControllerDocsTest extends RestDocsSupport {
+
+    @Override
+    protected Object initController() {
+        return new DailyTodoProofController();
+    }
+
+    @DisplayName("데일리 투두 수행 인증 검사 API")
+    @Test
+    void reviewDailyTodoProof() throws Exception {
+        final long todoProofId = 1L;
+        final ReviewDailyTodoProofRequest request = new ReviewDailyTodoProofRequest(
+            "REJECT",
+            "그게 정말 최선이야?"
+        );
+
+        mockMvc.perform(
+                post("/api/todo-proofs/{todoProofId}/review", todoProofId)
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(convertToJson(request)))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("todoProofId")
+                        .description("데일리 투두 인증 id")
+                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"))),
+                requestFields(
+                    fieldWithPath("result")
+                        .description(generateLink(DAILY_TODO_PROOF_REVIEW_RESULT))
+                        .type(JsonFieldType.STRING)
+                        .attributes(constraints("정해진 값만 입력 허용")),
+                    fieldWithPath("rejectReason")
+                        .description("노인정 사유")
+                        .type(JsonFieldType.STRING)
+                        .optional()
+                        .attributes(constraints("노인정일 경우에만 사유 입력, 인정과 함께 해당 필드의 데이터를 보내면 해당 데이터는 무시됨."))),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING))));
+    }
+    
+    @DisplayName("검사할 투두 수행 인증 전체 조회 API")
+    @Test        
+    void getDailyTodoProofsForReview() throws Exception {
+        mockMvc.perform(
+                get("/api/todo-proofs/pending-review")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todoProofs")
+                        .description("검사할 투두 수행 인증 리스트")
+                        .type(JsonFieldType.ARRAY)
+                        .optional(),
+                    fieldWithPath("data.todoProofs[].id")
+                        .description("투두 수행 인증 id")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.todoProofs[].content")
+                        .description("수행 인증 본문")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todoProofs[].proofMediaUrls")
+                        .description("수행 인증한 투두 내용")
+                        .type(JsonFieldType.ARRAY)
+                        .optional(),
+                    fieldWithPath("data.todoProofs[].todoContent")
+                        .description("수행 인증한 투두 내용")
+                        .type(JsonFieldType.STRING)
+                )));
+    }
+
+    @DisplayName("검사할 특정 투두 수행 인증 상세 조회 API")
+    @Test
+    void getDailyTodoProofForReviewById() throws Exception {
+        final long todoProofId = 1L;
+
+        mockMvc.perform(
+                get("/api/todo-proofs/pending-review/{todoProofId}", todoProofId)
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("todoProofId")
+                        .description("데일리 투두 인증 id")
+                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"))),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.id")
+                        .description("투두 수행 인증 id")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.content")
+                        .description("수행 인증 본문")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.proofMediaUrls")
+                        .description("수행 인증한 투두 내용")
+                        .type(JsonFieldType.ARRAY)
+                        .optional(),
+                    fieldWithPath("data.todoContent")
+                        .description("수행 인증한 투두 내용")
+                        .type(JsonFieldType.STRING)
+                )));
+    }
+}

--- a/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
@@ -44,7 +44,7 @@ public class DailyTodoProofControllerDocsTest extends RestDocsSupport {
                 pathParameters(
                     parameterWithName("todoProofId")
                         .description("데일리 투두 인증 id")
-                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"))),
+                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"), pathVariableExample(todoProofId))),
                 requestFields(
                     fieldWithPath("result")
                         .description(generateLink(DAILY_TODO_PROOF_REVIEW_RESULT))
@@ -114,7 +114,7 @@ public class DailyTodoProofControllerDocsTest extends RestDocsSupport {
                 pathParameters(
                     parameterWithName("todoProofId")
                         .description("데일리 투두 인증 id")
-                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"))),
+                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"), pathVariableExample(todoProofId))),
                 responseFields(
                     fieldWithPath("code")
                         .description("응답 코드")

--- a/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodoproof/DailyTodoProofControllerDocsTest.java
@@ -91,7 +91,7 @@ public class DailyTodoProofControllerDocsTest extends RestDocsSupport {
                         .description("수행 인증 본문")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.todoProofs[].proofMediaUrls")
-                        .description("수행 인증한 투두 내용")
+                        .description("인증에 포함된 미디어 리소스")
                         .type(JsonFieldType.ARRAY)
                         .optional(),
                     fieldWithPath("data.todoProofs[].todoContent")
@@ -129,7 +129,7 @@ public class DailyTodoProofControllerDocsTest extends RestDocsSupport {
                         .description("수행 인증 본문")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.proofMediaUrls")
-                        .description("수행 인증한 투두 내용")
+                        .description("인증에 포함된 미디어 리소스")
                         .type(JsonFieldType.ARRAY)
                         .optional(),
                     fieldWithPath("data.todoContent")

--- a/src/test/java/site/dogether/docs/dailytodoproof/enumtype/DailyTodoProofReviewResultDocs.java
+++ b/src/test/java/site/dogether/docs/dailytodoproof/enumtype/DailyTodoProofReviewResultDocs.java
@@ -2,6 +2,7 @@ package site.dogether.docs.dailytodoproof.enumtype;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import site.dogether.dailytodoproof.domain.DailyTodoProofReviewResult;
 import site.dogether.docs.util.RestDocsEnumType;
 
 @Getter
@@ -12,6 +13,14 @@ public enum DailyTodoProofReviewResultDocs implements RestDocsEnumType {
     REJECT("노인정", "REJECT")
     ;
 
+    private static final int enumValueCount = DailyTodoProofReviewResult.values().length;
+
     private final String description;
     private final String requestValue;
+
+    public static RestDocsEnumType[] getValues() {
+        final DailyTodoProofReviewResultDocs[] values = DailyTodoProofReviewResultDocs.values();
+        RestDocsEnumType.checkDocsValueCountIsEqualToEnumValueCount(enumValueCount, values.length);
+        return values;
+    }
 }

--- a/src/test/java/site/dogether/docs/dailytodoproof/enumtype/DailyTodoProofReviewResultDocs.java
+++ b/src/test/java/site/dogether/docs/dailytodoproof/enumtype/DailyTodoProofReviewResultDocs.java
@@ -1,0 +1,17 @@
+package site.dogether.docs.dailytodoproof.enumtype;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.docs.util.RestDocsEnumType;
+
+@Getter
+@RequiredArgsConstructor
+public enum DailyTodoProofReviewResultDocs implements RestDocsEnumType {
+
+    APPROVE("인정", "APPROVE"),
+    REJECT("노인정", "REJECT")
+    ;
+
+    private final String description;
+    private final String requestValue;
+}

--- a/src/test/java/site/dogether/docs/util/CommonDocsController.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.dogether.challengegroup.domain.ChallengeGroupDurationOption;
 import site.dogether.challengegroup.domain.ChallengeGroupStartAtOption;
-import site.dogether.common.constant.EnumType;
+import site.dogether.common.docs.RestDocsEnumType;
 import site.dogether.dailytodoproof.domain.DailyTodoProofReviewResult;
 
 import java.util.Arrays;
@@ -25,8 +25,8 @@ public class CommonDocsController {
         return new EnumDocs(challengeGroupStartAtOption, challengeGroupDurationOption, dailyTodoProofReviewResult);
     }
 
-    private Map<String, String> convertToMap(final EnumType[] enumTypes) {
-        return Arrays.stream(enumTypes)
-                     .collect(toMap(EnumType::getValue, EnumType::getDescription));
+    private Map<String, String> convertToMap(final RestDocsEnumType[] restDocsEnumTypes) {
+        return Arrays.stream(restDocsEnumTypes)
+                     .collect(toMap(RestDocsEnumType::getValue, RestDocsEnumType::getDescription));
     }
 }

--- a/src/test/java/site/dogether/docs/util/CommonDocsController.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.dogether.challengegroup.domain.ChallengeGroupDurationOption;
 import site.dogether.challengegroup.domain.ChallengeGroupStartAtOption;
 import site.dogether.common.constant.EnumType;
+import site.dogether.dailytodoproof.domain.DailyTodoProofReviewResult;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -20,7 +21,8 @@ public class CommonDocsController {
     public EnumDocs findEnums() {
         final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOption.values());
         final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOption.values());
-        return new EnumDocs(challengeGroupStartAtOption, challengeGroupDurationOption);
+        final Map<String, String> dailyTodoProofReviewResult = convertToMap(DailyTodoProofReviewResult.values());
+        return new EnumDocs(challengeGroupStartAtOption, challengeGroupDurationOption, dailyTodoProofReviewResult);
     }
 
     private Map<String, String> convertToMap(final EnumType[] enumTypes) {

--- a/src/test/java/site/dogether/docs/util/CommonDocsController.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsController.java
@@ -3,10 +3,9 @@ package site.dogether.docs.util;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import site.dogether.challengegroup.domain.ChallengeGroupDurationOption;
-import site.dogether.challengegroup.domain.ChallengeGroupStartAtOption;
-import site.dogether.common.docs.RestDocsEnumType;
-import site.dogether.dailytodoproof.domain.DailyTodoProofReviewResult;
+import site.dogether.docs.challengegroup.enumtype.ChallengeGroupDurationOptionDocs;
+import site.dogether.docs.challengegroup.enumtype.ChallengeGroupStartAtOptionDocs;
+import site.dogether.docs.dailytodoproof.enumtype.DailyTodoProofReviewResultDocs;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -19,14 +18,14 @@ public class CommonDocsController {
 
     @GetMapping("/enums")
     public EnumDocs findEnums() {
-        final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOption.values());
-        final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOption.values());
-        final Map<String, String> dailyTodoProofReviewResult = convertToMap(DailyTodoProofReviewResult.values());
+        final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOptionDocs.values());
+        final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOptionDocs.values());
+        final Map<String, String> dailyTodoProofReviewResult = convertToMap(DailyTodoProofReviewResultDocs.values());
         return new EnumDocs(challengeGroupStartAtOption, challengeGroupDurationOption, dailyTodoProofReviewResult);
     }
 
     private Map<String, String> convertToMap(final RestDocsEnumType[] restDocsEnumTypes) {
         return Arrays.stream(restDocsEnumTypes)
-                     .collect(toMap(RestDocsEnumType::getValue, RestDocsEnumType::getDescription));
+                     .collect(toMap(RestDocsEnumType::getRequestValue, RestDocsEnumType::getDescription));
     }
 }

--- a/src/test/java/site/dogether/docs/util/CommonDocsController.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsController.java
@@ -18,10 +18,14 @@ public class CommonDocsController {
 
     @GetMapping("/enums")
     public EnumDocs findEnums() {
-        final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOptionDocs.values());
-        final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOptionDocs.values());
-        final Map<String, String> dailyTodoProofReviewResult = convertToMap(DailyTodoProofReviewResultDocs.values());
-        return new EnumDocs(challengeGroupStartAtOption, challengeGroupDurationOption, dailyTodoProofReviewResult);
+        final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOptionDocs.getValues());
+        final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOptionDocs.getValues());
+        final Map<String, String> dailyTodoProofReviewResult = convertToMap(DailyTodoProofReviewResultDocs.getValues());
+        return EnumDocs.builder()
+                   .challengeGroupStartAtOption(challengeGroupStartAtOption)
+                   .challengeGroupDurationOption(challengeGroupDurationOption)
+                   .dailyTodoProofReviewResult(dailyTodoProofReviewResult)
+                   .build();
     }
 
     private Map<String, String> convertToMap(final RestDocsEnumType[] restDocsEnumTypes) {

--- a/src/test/java/site/dogether/docs/util/CommonDocsControllerTest.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsControllerTest.java
@@ -39,11 +39,14 @@ public class CommonDocsControllerTest extends RestDocsSupport {
         result.andExpect(status().isOk())
             .andDo(createDocument(
                 customResponseFields("custom-response", beneathPath("challengeGroupStartAtOption"),
-                    attributes(key("title").value("challengeGroupStartAtOption")),
+                    attributes(key("title").value("그룹 시작일 옵션")),
                     convertEnumToFieldDescriptor((enumDocs.getChallengeGroupStartAtOption()))),
                 customResponseFields("custom-response", beneathPath("challengeGroupDurationOption"),
-                    attributes(key("title").value("challengeGroupDurationOption")),
-                    convertEnumToFieldDescriptor((enumDocs.getChallengeGroupDurationOption())))
+                    attributes(key("title").value("그룹 진행 기간 옵션")),
+                    convertEnumToFieldDescriptor((enumDocs.getChallengeGroupDurationOption()))),
+                customResponseFields("custom-response", beneathPath("dailyTodoProofReviewResult"),
+                    attributes(key("title").value("데일리 투두 수행 인증 검사 결과 옵션")),
+                    convertEnumToFieldDescriptor((enumDocs.getDailyTodoProofReviewResult())))
             ));
     }
 

--- a/src/test/java/site/dogether/docs/util/DocumentLinkGenerator.java
+++ b/src/test/java/site/dogether/docs/util/DocumentLinkGenerator.java
@@ -9,6 +9,7 @@ public final class DocumentLinkGenerator {
     public enum DocUrl {
         CHALLENGE_GROUP_START_AT_OPTION("challenge-group-start-at-option", "그룹 시작일 옵션"),
         CHALLENGE_GROUP_DURATION_OPTION("challenge-group-duration-option", "그룹 진행 기간 옵션"),
+        DAILY_TODO_PROOF_REVIEW_RESULT("daily-todo-proof-review-result", "데일리 투두 수행 인증 검사 결과 옵션"),
         ;
 
         private final String fileName;

--- a/src/test/java/site/dogether/docs/util/EnumDocs.java
+++ b/src/test/java/site/dogether/docs/util/EnumDocs.java
@@ -1,35 +1,16 @@
 package site.dogether.docs.util;
 
+import lombok.*;
+
 import java.util.Map;
 
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class EnumDocs {
 
     Map<String, String> challengeGroupStartAtOption;
     Map<String, String> challengeGroupDurationOption;
     Map<String, String> dailyTodoProofReviewResult;
-
-    public EnumDocs() {
-    }
-
-    public EnumDocs(
-        final Map<String, String> challengeGroupStartAtOption,
-        final Map<String, String> challengeGroupDurationOption,
-        final Map<String, String> dailyTodoProofReviewResult
-    ) {
-        this.challengeGroupStartAtOption = challengeGroupStartAtOption;
-        this.challengeGroupDurationOption = challengeGroupDurationOption;
-        this.dailyTodoProofReviewResult = dailyTodoProofReviewResult;
-    }
-
-    public Map<String, String> getChallengeGroupStartAtOption() {
-        return challengeGroupStartAtOption;
-    }
-
-    public Map<String, String> getChallengeGroupDurationOption() {
-        return challengeGroupDurationOption;
-    }
-
-    public Map<String, String> getDailyTodoProofReviewResult() {
-        return dailyTodoProofReviewResult;
-    }
 }

--- a/src/test/java/site/dogether/docs/util/EnumDocs.java
+++ b/src/test/java/site/dogether/docs/util/EnumDocs.java
@@ -6,16 +6,19 @@ public class EnumDocs {
 
     Map<String, String> challengeGroupStartAtOption;
     Map<String, String> challengeGroupDurationOption;
+    Map<String, String> dailyTodoProofReviewResult;
 
     public EnumDocs() {
     }
 
     public EnumDocs(
         final Map<String, String> challengeGroupStartAtOption,
-        final Map<String, String> challengeGroupDurationOption
+        final Map<String, String> challengeGroupDurationOption,
+        final Map<String, String> dailyTodoProofReviewResult
     ) {
         this.challengeGroupStartAtOption = challengeGroupStartAtOption;
         this.challengeGroupDurationOption = challengeGroupDurationOption;
+        this.dailyTodoProofReviewResult = dailyTodoProofReviewResult;
     }
 
     public Map<String, String> getChallengeGroupStartAtOption() {
@@ -24,5 +27,9 @@ public class EnumDocs {
 
     public Map<String, String> getChallengeGroupDurationOption() {
         return challengeGroupDurationOption;
+    }
+
+    public Map<String, String> getDailyTodoProofReviewResult() {
+        return dailyTodoProofReviewResult;
     }
 }

--- a/src/test/java/site/dogether/docs/util/RestDocsEnumType.java
+++ b/src/test/java/site/dogether/docs/util/RestDocsEnumType.java
@@ -1,7 +1,7 @@
-package site.dogether.common.docs;
+package site.dogether.docs.util;
 
 public interface RestDocsEnumType {
 
     String getDescription();
-    String getValue();
+    String getRequestValue();
 }

--- a/src/test/java/site/dogether/docs/util/RestDocsEnumType.java
+++ b/src/test/java/site/dogether/docs/util/RestDocsEnumType.java
@@ -4,4 +4,10 @@ public interface RestDocsEnumType {
 
     String getDescription();
     String getRequestValue();
+
+    static void checkDocsValueCountIsEqualToEnumValueCount(final int enumValueCount, final int enumDocsValueCount) {
+        if (enumDocsValueCount != enumValueCount) {
+            throw new IllegalStateException("Enum의 값 개수와 문서의 값 개수가 일치하지 않습니다.");
+        }
+    }
 }

--- a/src/test/java/site/dogether/docs/util/RestDocsSupport.java
+++ b/src/test/java/site/dogether/docs/util/RestDocsSupport.java
@@ -29,6 +29,10 @@ public abstract class RestDocsSupport {
         return new Attributes.Attribute("constraints", value);
     }
 
+    protected static Attributes.Attribute pathVariableExample(final long value) {
+        return new Attributes.Attribute("pathVariableExample", value);
+    }
+
     @BeforeEach
     void setUp(final RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,11 +1,12 @@
 ===== Path Variables
 |===
-|설명|제약조건
+|설명|제약조건|예시값
 
 {{#parameters}}
 
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 |{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#pathVariableExample}}{{.}}{{/pathVariableExample}}{{/tableCellContent}}
 
 {{/parameters}}
 |===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,12 +1,13 @@
 ===== Response Fields
 |===
-|설명|경로|타입
+|설명|경로|타입|공백 여부
 
 {{#fields}}
 
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{^optional}}X{{/optional}}{{/tableCellContent}}
 
 {{/fields}}
 


### PR DESCRIPTION
데일리 투두 & 투두 수행 API 문서 작성 및 Mock API 구현 완료
-  어제 작성한 투두 내용 조회
-  데일리 투두 작성
-  검사할 투두 수행 인증 전체 조회
-  검사할 특정 투두 수행 인증 상세 조회
-  투두 수행 인증 검사

투두 수행 인증은 아직 클라이언트의 미디어 전송 방식이 결정되지 않아서 향 후 따로 작성합니다.