### PR TITLE
[BE] NotificationTokenJpaEntity value 컬럼 길이 제한을 500으로 변경

### DIFF
--- a/src/main/java/site/dogether/notification/infrastructure/entity/NotificationTokenJpaEntity.java
+++ b/src/main/java/site/dogether/notification/infrastructure/entity/NotificationTokenJpaEntity.java
@@ -21,7 +21,7 @@ public class NotificationTokenJpaEntity extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private MemberJpaEntity member;
 
-    @Column(name = "value", length = 100, nullable = false, unique = true)
+    @Column(name = "value", length = 500, nullable = false, unique = true)
     private String value;
 
     public NotificationTokenJpaEntity(final MemberJpaEntity member, final String value) {


### PR DESCRIPTION
FCM Token 길이를 고려해 value 컬럼 길이 제한을 500으로 변경

This closes #17 