### PR TITLE
[BE] 그룹 기능 변경 사항 반영

### DIFF
--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -9,7 +9,7 @@
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X
@@ -31,7 +31,7 @@ include::{snippets}/auth-controller-docs-test/login/response-fields.adoc[]
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X

--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -31,7 +31,7 @@ include::{snippets}/challenge-group-controller-docs-test/create-challenge-group/
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X
@@ -53,7 +53,7 @@ include::{snippets}/challenge-group-controller-docs-test/join-challenge-group/re
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X
@@ -74,7 +74,7 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X
@@ -95,7 +95,7 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 | 환경 | 구현 여부
 
 | 개발
-| X
+| O
 
 | 운영
 | X
@@ -107,3 +107,24 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 ==== HTTP Response
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-team-activity-summary/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-team-activity-summary/response-fields.adoc[]
+
+[[is-joined-challenge-group]]
+=== 챌린지 그룹 참여 여부 확인
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| O
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/challenge-group-controller-docs-test/is-joining-challenge-group/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/challenge-group-controller-docs-test/is-joining-challenge-group/http-response.adoc[]
+include::{snippets}/challenge-group-controller-docs-test/is-joining-challenge-group/response-fields.adoc[]

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -6,7 +6,6 @@ import static site.dogether.challengegroup.controller.response.ChallengeGroupSuc
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.JOIN_CHALLENGE_GROUP;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +19,7 @@ import site.dogether.challengegroup.controller.response.CreateChallengeGroupResp
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupInfoResponse;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupMyActivitySummaryResponse;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupTeamActivitySummaryResponse;
+import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupTeamActivitySummaryResponse.RankResponse;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.JoiningChallengeGroupTeamActivityDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupInfo;
@@ -98,25 +98,6 @@ public class ChallengeGroupController {
             ApiResponse.successWithData(
                 GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY,
                 new GetJoiningChallengeGroupTeamActivitySummaryResponse(
-                        joiningChallengeGroupTeamActivityDto.totalTodoCount(),
-                        joiningChallengeGroupTeamActivityDto.totalCertificatedCount(),
-                        joiningChallengeGroupTeamActivityDto.totalApprovedCount(),
-                        List.of(
-                            new GetJoiningChallengeGroupTeamActivitySummaryResponse.RankResponse(
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(0).getRank(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(0).getName(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(0).getCertificationRate(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(0).getApprovalRate()),
-                            new GetJoiningChallengeGroupTeamActivitySummaryResponse.RankResponse(
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(1).getRank(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(1).getName(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(1).getCertificationRate(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(1).getApprovalRate()),
-                            new GetJoiningChallengeGroupTeamActivitySummaryResponse.RankResponse(
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(2).getRank(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(2).getName(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(2).getCertificationRate(),
-                                    joiningChallengeGroupTeamActivityDto.ranking().get(2).getApprovalRate())))
-            ));
+                        RankResponse.of(joiningChallengeGroupTeamActivityDto.ranking()))));
     }
 }

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -1,6 +1,7 @@
 package site.dogether.challengegroup.controller;
 
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.CREATE_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_IS_JOINED_CHALLENGE_GROUP;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_INFO;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_MY_ACTIVITY_SUMMARY;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY;
@@ -99,5 +100,17 @@ public class ChallengeGroupController {
                 GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY,
                 new GetJoiningChallengeGroupTeamActivitySummaryResponse(
                         RankResponse.of(joiningChallengeGroupTeamActivityDto.ranking()))));
+    }
+
+    @GetMapping("/isJoined")
+    public ResponseEntity<ApiResponse<Boolean>> isJoinedChallengeGroup(
+            @Authentication final String authenticationToken
+    ) {
+        final boolean isJoined = challengeGroupService.isJoinedChallengeGroup(authenticationToken);
+        return ResponseEntity.ok(
+                ApiResponse.successWithData(
+                        GET_IS_JOINED_CHALLENGE_GROUP,
+                        isJoined
+                ));
     }
 }

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -66,8 +66,10 @@ public class ChallengeGroupController {
                 GET_JOINING_CHALLENGE_GROUP_INFO,
                 new GetJoiningChallengeGroupInfoResponse(
                         joiningGroupInfo.name(),
-                        joiningGroupInfo.currentMemberCount(),
-                        joiningGroupInfo.maximumTodoCount())));
+                        joiningGroupInfo.duration(),
+                        joiningGroupInfo.joinCode(),
+                        joiningGroupInfo.endAt(),
+                        joiningGroupInfo.remainingDays())));
     }
 
     @GetMapping("/summary/my")

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -84,7 +84,8 @@ public class ChallengeGroupController {
                 new GetJoiningChallengeGroupMyActivitySummaryResponse(
                         joiningChallengeGroupMyActivityDto.totalTodoCount(),
                         joiningChallengeGroupMyActivityDto.totalCertificatedCount(),
-                        joiningChallengeGroupMyActivityDto.totalApprovedCount())));
+                        joiningChallengeGroupMyActivityDto.totalApprovedCount(),
+                        joiningChallengeGroupMyActivityDto.totalRejectedCount())));
     }
 
     @GetMapping("/summary/team")

--- a/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
@@ -13,6 +13,7 @@ public enum ChallengeGroupSuccessCode implements SuccessCode {
     GET_JOINING_CHALLENGE_GROUP_INFO("CGS-0003", "참여중인 그룹 정보를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_MY_ACTIVITY_SUMMARY("CGS-0004", "참여중인 그룹의 내 누적 활동 통계 정보를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY("CGS-0005", "참여중인 그룹의 팀 전체 누적 활동 통계 정보를 조회하였습니다."),
+    GET_IS_JOINED_CHALLENGE_GROUP("CGS-0006", "챌린지 그룹 참여 여부를 조회하였습니다."),
     ;
 
     private final String value;

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupInfoResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupInfoResponse.java
@@ -2,7 +2,9 @@ package site.dogether.challengegroup.controller.response;
 
 public record GetJoiningChallengeGroupInfoResponse(
     String name,
-    int currentMemberCount,
-    int maximumTodoCount
+    int duration,
+    String joinCode,
+    String endAt,
+    int remainingDays
 ) {
 }

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupMyActivitySummaryResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupMyActivitySummaryResponse.java
@@ -3,6 +3,7 @@ package site.dogether.challengegroup.controller.response;
 public record GetJoiningChallengeGroupMyActivitySummaryResponse(
     int totalTodoCount,
     int totalCertificatedCount,
-    int totalApprovedCount
+    int totalApprovedCount,
+    int totalRejectedCount
 ) {
 }

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupTeamActivitySummaryResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupTeamActivitySummaryResponse.java
@@ -1,17 +1,20 @@
 package site.dogether.challengegroup.controller.response;
 
 import java.util.List;
+import site.dogether.dailytodo.domain.Rank;
 
 public record GetJoiningChallengeGroupTeamActivitySummaryResponse(
-    int totalTodoCount,
-    int totalCertificatedCount,
-    int totalApprovedCount,
     List<RankResponse> ranking
 ) {
     public record RankResponse(
         int rank,
         String name,
-        double certificationRate,
-        double approvalRate
-    ) {}
+        double certificationRate
+    ) {
+        public static List<RankResponse> of(List<Rank> ranks) {
+            return ranks.stream()
+                .map(rank -> new RankResponse(rank.getRank(), rank.getName(), rank.getCertificationRate()))
+                .toList();
+        }
+    }
 }

--- a/src/main/java/site/dogether/challengegroup/domain/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/domain/ChallengeGroup.java
@@ -122,5 +122,4 @@ public class ChallengeGroup {
         return UUID.randomUUID().toString()
                 .substring(JOIN_CODE_PARSING_START_INDEX, JOIN_CODE_PARSING_END_INDEX);
     }
-
 }

--- a/src/main/java/site/dogether/challengegroup/infrastructure/repository/ChallengeGroupJpaRepository.java
+++ b/src/main/java/site/dogether/challengegroup/infrastructure/repository/ChallengeGroupJpaRepository.java
@@ -1,5 +1,6 @@
 package site.dogether.challengegroup.infrastructure.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.dogether.challengegroup.infrastructure.entity.ChallengeGroupJpaEntity;
@@ -7,4 +8,6 @@ import site.dogether.challengegroup.infrastructure.entity.ChallengeGroupJpaEntit
 public interface ChallengeGroupJpaRepository extends JpaRepository<ChallengeGroupJpaEntity, Long> {
 
     Optional<ChallengeGroupJpaEntity> findByJoinCode(String joinCode);
+
+    LocalDateTime findEndAtById(Long id);
 }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -1,5 +1,8 @@
 package site.dogether.challengegroup.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,12 +113,18 @@ public class ChallengeGroupService {
         final ChallengeGroup joiningGroup = challengeGroupJpaEntity.toDomain();
         isGroupFinished(joiningGroup);
 
-        final int currentMemberCount = challengeGroupMemberJpaRepository.countByChallengeGroup(challengeGroupJpaEntity);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // TODO : 도메인으로 이동
+        LocalDateTime endAt = challengeGroupJpaEntity.getEndAt();
+        String endAtFormatted = endAt.format(formatter);
+
+        long remainingDays = LocalDateTime.now().until(endAt, ChronoUnit.DAYS);
 
         return new JoiningChallengeGroupInfo(
                 joiningGroup.getName(),
-                currentMemberCount,
-                joiningGroup.getMaximumTodoCount()
+                joiningGroup.getDurationOption().getValue(),
+                joiningGroup.getJoinCode(),
+                endAtFormatted,
+                (int) remainingDays
         );
     }
 

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -184,4 +184,15 @@ public class ChallengeGroupService {
                 groupTodoSummary.getRanks()
         );
     }
+
+    public boolean isJoinedChallengeGroup(final String authenticationToken) {
+        final MemberJpaEntity memberJpaEntity = memberService.findMemberEntityByAuthenticationToken(authenticationToken);
+        final ChallengeGroupMemberJpaEntity challengeGroupMemberJpaEntity =
+                challengeGroupMemberJpaRepository.findByMember(memberJpaEntity)
+                        .orElseThrow(() -> new InvalidChallengeGroupException("그룹에 속해있지 않은 유저입니다."));
+        final ChallengeGroupJpaEntity joiningGroupEntity = challengeGroupMemberJpaEntity.getChallengeGroup();
+        final ChallengeGroup joiningGroup = joiningGroupEntity.toDomain();
+
+        return joiningGroup.isRunning();
+    }
 }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -157,7 +157,8 @@ public class ChallengeGroupService {
         return new JoiningChallengeGroupMyActivityDto(
                 myTodoSummary.calculateTotalTodoCount(),
                 myTodoSummary.calculateTotalCertificatedCount(),
-                myTodoSummary.calculateTotalApprovedCount()
+                myTodoSummary.calculateTotalApprovedCount(),
+                myTodoSummary.calculateTotalRejectedCount()
         );
     }
 

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -181,10 +181,7 @@ public class ChallengeGroupService {
         final GroupTodoSummary groupTodoSummary = new GroupTodoSummary(myTodoSummaries);
 
         return new JoiningChallengeGroupTeamActivityDto(
-                groupTodoSummary.calculateTotalTodoCount(),
-                groupTodoSummary.calculateTotalCertificatedCount(),
-                groupTodoSummary.calculateTotalApprovedCount(),
-                groupTodoSummary.getRanksOfTop3()
+                groupTodoSummary.getRanks()
         );
     }
 }

--- a/src/main/java/site/dogether/challengegroup/service/JoiningChallengeGroupTeamActivityDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/JoiningChallengeGroupTeamActivityDto.java
@@ -4,9 +4,6 @@ import java.util.List;
 import site.dogether.dailytodo.domain.Rank;
 
 public record JoiningChallengeGroupTeamActivityDto(
-    int totalTodoCount,
-    int totalCertificatedCount,
-    int totalApprovedCount,
     List<Rank> ranking
 ) {
 }

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupInfo.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupInfo.java
@@ -2,7 +2,9 @@ package site.dogether.challengegroup.service.dto;
 
 public record JoiningChallengeGroupInfo(
     String name,
-    int currentMemberCount,
-    int maximumTodoCount
+    int duration,
+    String joinCode,
+    String endAt,
+    int remainingDays
 ) {
 }

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupMyActivityDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupMyActivityDto.java
@@ -3,6 +3,7 @@ package site.dogether.challengegroup.service.dto;
 public record JoiningChallengeGroupMyActivityDto(
         int totalTodoCount,
         int totalCertificatedCount,
-        int totalApprovedCount
+        int totalApprovedCount,
+        int totalRejectedCount
 ) {
 }

--- a/src/main/java/site/dogether/dailytodo/domain/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/domain/DailyTodo.java
@@ -130,4 +130,8 @@ public class DailyTodo {
     public boolean isApproved() {
         return status == APPROVE;
     }
+
+    public boolean isRejected() {
+        return status == REJECT;
+    }
 }

--- a/src/main/java/site/dogether/dailytodo/domain/GroupTodoSummary.java
+++ b/src/main/java/site/dogether/dailytodo/domain/GroupTodoSummary.java
@@ -11,31 +11,12 @@ public class GroupTodoSummary {
         this.myTodoSummaries = myTodoSummaries;
     }
 
-    public int calculateTotalTodoCount() {
-        return myTodoSummaries.stream()
-                .mapToInt(MyTodoSummary::calculateTotalTodoCount)
-                .sum();
-    }
-
-    public int calculateTotalCertificatedCount() {
-        return myTodoSummaries.stream()
-                .mapToInt(MyTodoSummary::calculateTotalCertificatedCount)
-                .sum();
-    }
-
-    public int calculateTotalApprovedCount() {
-        return myTodoSummaries.stream()
-                .mapToInt(MyTodoSummary::calculateTotalApprovedCount)
-                .sum();
-    }
-
-    public List<Rank> getRanksOfTop3() {
+    public List<Rank> getRanks() {
         final List<Rank> allRanking = myTodoSummaries.stream()
                 .map(myTodoSummary -> new Rank(
                         0,
                         myTodoSummary.getMyTodos().get(0).getMember().getName(),
-                        myTodoSummary.calculateCertificationRate(),
-                        myTodoSummary.calculateApprovalRate()
+                        myTodoSummary.calculateCertificationRate()
                 ))
                 .sorted((o1, o2) -> (int) (o2.getCertificationRate() - o1.getCertificationRate()))
                 .toList();
@@ -43,11 +24,7 @@ public class GroupTodoSummary {
         IntStream.range(0, allRanking.size())
                 .forEach(i -> allRanking.get(i).setRank(i + 1));
 
-        return List.of(
-                allRanking.get(0),
-                allRanking.size() > 1 ? allRanking.get(1) : new Rank(2, null, 0, 0),
-                allRanking.size() > 2 ? allRanking.get(2) : new Rank(3, null, 0, 0)
-        );
+        return allRanking;
     }
 
 }

--- a/src/main/java/site/dogether/dailytodo/domain/MyTodoSummary.java
+++ b/src/main/java/site/dogether/dailytodo/domain/MyTodoSummary.java
@@ -41,4 +41,10 @@ public class MyTodoSummary {
         final int totalApprovedCount = calculateTotalApprovedCount();
         return (double) totalApprovedCount / totalTodoCount;
     }
+
+    public int calculateTotalRejectedCount() {
+        return (int) myTodos.stream()
+            .filter(DailyTodo::isRejected)
+            .count();
+    }
 }

--- a/src/main/java/site/dogether/dailytodo/domain/Rank.java
+++ b/src/main/java/site/dogether/dailytodo/domain/Rank.java
@@ -10,16 +10,13 @@ public class Rank {
     private int rank;
     private final String name;
     private final double certificationRate;
-    private final double approvalRate;
 
     public Rank(final int rank,
                 final String name,
-                final double certificationRate,
-                final double approvalRate) {
+                final double certificationRate) {
         this.rank = rank;
         this.name = name;
         this.certificationRate = certificationRate;
-        this.approvalRate = approvalRate;
     }
 
 }

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -123,7 +123,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     @Test        
     void getJoiningChallengeGroupInfo() throws Exception {
         given(challengeGroupService.getJoiningChallengeGroupInfo(any()))
-            .willReturn(new JoiningChallengeGroupInfo("성욱이와 친구들", 5, 7));
+            .willReturn(new JoiningChallengeGroupInfo("성욱이와 친구들", 7, "Join Code", "2025-02-25", 5));
 
         mockMvc.perform(
                 get("/api/groups/info/current")
@@ -141,11 +141,17 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.name")
                         .description("그룹명")
                         .type(JsonFieldType.STRING),
-                    fieldWithPath("data.currentMemberCount")
-                        .description("그룹 인원수")
+                    fieldWithPath("data.duration")
+                        .description("챌린지 기간")
                         .type(JsonFieldType.NUMBER),
-                    fieldWithPath("data.maximumTodoCount")
-                        .description("하루 최대 작성 가능 투두 개수")
+                    fieldWithPath("data.joinCode")
+                        .description("그룹 참여 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.endAt")
+                        .description("챌린지 종료일")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.remainingDays")
+                        .description("남은 일수")
                         .type(JsonFieldType.NUMBER))));
     }
     

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -227,4 +227,26 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.NUMBER))
             ));
     }
+
+
+    @DisplayName("챌린지 그룹 참여 여부 조회 API")
+    @Test
+    void isJoiningChallengeGroup() throws Exception {
+        mockMvc.perform(
+                        get("/api/groups/isJoined")
+                                .header("Authorization", "Bearer access_token")
+                                .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andDo(createDocument(
+                        responseFields(
+                                fieldWithPath("code")
+                                        .description("응답 코드")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("message")
+                                        .description("응답 메시지")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data")
+                                        .description("참여중인 그룹 여부")
+                                        .type(JsonFieldType.BOOLEAN))));
+    }
 }

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -159,7 +159,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     @Test        
     void getJoiningChallengeGroupMyActivitySummary() throws Exception {
         given(challengeGroupService.getJoiningChallengeGroupMyActivitySummary(any()))
-            .willReturn(new JoiningChallengeGroupMyActivityDto(10, 5, 3));
+            .willReturn(new JoiningChallengeGroupMyActivityDto(10, 5, 3, 2));
 
         mockMvc.perform(
                 get("/api/groups/summary/my")
@@ -181,7 +181,10 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .description("인증한 전체 투두 개수")
                         .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.totalApprovedCount")
-                        .description("인정받은 전체 투두 개수")
+                        .description("인정받은 투두 개수")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.totalRejectedCount")
+                        .description("노인정 투두 개수")
                         .type(JsonFieldType.NUMBER))));
     }
     
@@ -189,11 +192,11 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     @Test        
     void getJoiningChallengeGroupTeamActivitySummary() throws Exception {
         given(challengeGroupService.getJoiningChallengeGroupTeamActivitySummary(any()))
-            .willReturn(new JoiningChallengeGroupTeamActivityDto(10, 5, 3,
+            .willReturn(new JoiningChallengeGroupTeamActivityDto(
                 List.of(
-                    new Rank(1, "성욱", 0.5, 0.3),
-                    new Rank(2, "영재", 0.4, 0.2),
-                    new Rank(3, "지원", 0.3, 0.1)
+                    new Rank(1, "성욱", 0.5),
+                    new Rank(2, "영재", 0.4),
+                    new Rank(3, "지원", 0.3)
             )));
 
         mockMvc.perform(
@@ -209,15 +212,6 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("message")
                         .description("응답 메시지")
                         .type(JsonFieldType.STRING),
-                    fieldWithPath("data.totalTodoCount")
-                        .description("작성한 전체 투두 개수")
-                        .type(JsonFieldType.NUMBER),
-                    fieldWithPath("data.totalCertificatedCount")
-                        .description("인증한 전체 투두 개수")
-                        .type(JsonFieldType.NUMBER),
-                    fieldWithPath("data.totalApprovedCount")
-                        .description("인정받은 전체 투두 개수")
-                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.ranking")
                         .description("그룹 내 활동 순위")
                         .type(JsonFieldType.ARRAY)
@@ -230,9 +224,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.ranking[].certificationRate")
                         .description("데일리 투두 인증률")
-                        .type(JsonFieldType.NUMBER),
-                    fieldWithPath("data.ranking[].approvalRate")
-                        .description("데일리 투두 인정률")
-                        .type(JsonFieldType.NUMBER))));
+                        .type(JsonFieldType.NUMBER))
+            ));
     }
 }


### PR DESCRIPTION
- 유저 그룹 참여중 / 미참여 여부 API 구현

- 참여중인 그룹 조회 API 수정
response : 그룹명, 총 기간, 초대 코드, 종료일, 남은 일수

- 나의 통계 조회 기능 수정
response : 투두 개수, 인증 개수, 인정 개수, 노인정 개수

- 참여중인 그룹 내의 통계 조회 기능 수정
response : 순위 (이름, 달성률)
